### PR TITLE
[codex] Harden CSRF checks on write APIs

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -313,6 +313,26 @@ export function getSessionCookieName(env: AuthEnv): string {
 	return getEnv(env, "SESSION_COOKIE_NAME") || DEFAULT_SESSION_COOKIE;
 }
 
+export function requireSameOrigin(request: Request): Response | null {
+	const fetchSite = request.headers.get("Sec-Fetch-Site")?.toLowerCase();
+	if (fetchSite === "same-origin") {
+		return null;
+	}
+
+	const origin = request.headers.get("Origin");
+	if (origin) {
+		try {
+			if (new URL(origin).origin === new URL(request.url).origin) {
+				return null;
+			}
+		} catch {
+			return new Response("Same-origin request required.", { status: 403 });
+		}
+	}
+
+	return new Response("Same-origin request required.", { status: 403 });
+}
+
 function toSessionData(data: SessionInput, now: number): SessionData | null {
 	const email = typeof data.email === "string" ? data.email.trim().toLowerCase() : "";
 	if (!email) {

--- a/src/pages/api/admin/games.ts
+++ b/src/pages/api/admin/games.ts
@@ -225,6 +225,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 export const PATCH: APIRoute = async ({ request, locals }) => {
 	const { session, db, error } = await requireAdmin(request, locals);
 	if (!session || !db) return error!;
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);
@@ -414,6 +416,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 export const DELETE: APIRoute = async ({ request, locals }) => {
 	const { session, db, error } = await requireAdmin(request, locals);
 	if (!session || !db) return error!;
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);
@@ -618,12 +622,6 @@ async function requireAdmin(request: Request, locals: App.Locals) {
 	const session = await readSession(request, env);
 	if (!session) {
 		return { session: null, db: null, error: new Response("Authentication required.", { status: 401 }) };
-	}
-	if (request.method !== "GET" && request.method !== "HEAD") {
-		const sameOriginError = requireSameOrigin(request);
-		if (sameOriginError) {
-			return { session: null, db: null, error: sameOriginError };
-		}
 	}
 	if (session.role !== "admin") {
 		return { session: null, db: null, error: new Response("Admin access required.", { status: 403 }) };

--- a/src/pages/api/admin/games.ts
+++ b/src/pages/api/admin/games.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 import { fetchExternalGameMetadata, type ExternalGameMetadata } from "../../../lib/game-metadata";
 
@@ -71,6 +71,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}
@@ -616,6 +618,12 @@ async function requireAdmin(request: Request, locals: App.Locals) {
 	const session = await readSession(request, env);
 	if (!session) {
 		return { session: null, db: null, error: new Response("Authentication required.", { status: 401 }) };
+	}
+	if (request.method !== "GET" && request.method !== "HEAD") {
+		const sameOriginError = requireSameOrigin(request);
+		if (sameOriginError) {
+			return { session: null, db: null, error: sameOriginError };
+		}
 	}
 	if (session.role !== "admin") {
 		return { session: null, db: null, error: new Response("Admin access required.", { status: 403 }) };

--- a/src/pages/api/admin/members.ts
+++ b/src/pages/api/admin/members.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type MemberRow = {
@@ -58,6 +58,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}
@@ -111,6 +113,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}
@@ -207,6 +211,8 @@ export const DELETE: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}

--- a/src/pages/api/admin/polls.ts
+++ b/src/pages/api/admin/polls.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type PollHistoryRow = {
@@ -200,6 +200,12 @@ async function requireAdmin(request: Request, locals: App.Locals) {
 	const session = await readSession(request, env);
 	if (!session) {
 		return { session: null, db: null, env: null, error: new Response("Authentication required.", { status: 401 }) };
+	}
+	if (request.method !== "GET" && request.method !== "HEAD") {
+		const sameOriginError = requireSameOrigin(request);
+		if (sameOriginError) {
+			return { session: null, db: null, env: null, error: sameOriginError };
+		}
 	}
 	if (session.role !== "admin") {
 		return { session: null, db: null, env: null, error: new Response("Admin access required.", { status: 403 }) };

--- a/src/pages/api/admin/polls.ts
+++ b/src/pages/api/admin/polls.ts
@@ -69,6 +69,8 @@ export const GET: APIRoute = async ({ request, locals }) => {
 export const PATCH: APIRoute = async ({ request, locals }) => {
 	const { session, db, env, error } = await requireAdmin(request, locals);
 	if (!session || !db || !env) return error!;
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);
@@ -105,6 +107,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 export const DELETE: APIRoute = async ({ request, locals }) => {
 	const { session, db, env, error } = await requireAdmin(request, locals);
 	if (!session || !db || !env) return error!;
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);
@@ -200,12 +204,6 @@ async function requireAdmin(request: Request, locals: App.Locals) {
 	const session = await readSession(request, env);
 	if (!session) {
 		return { session: null, db: null, env: null, error: new Response("Authentication required.", { status: 401 }) };
-	}
-	if (request.method !== "GET" && request.method !== "HEAD") {
-		const sameOriginError = requireSameOrigin(request);
-		if (sameOriginError) {
-			return { session: null, db: null, env: null, error: sameOriginError };
-		}
 	}
 	if (session.role !== "admin") {
 		return { session: null, db: null, env: null, error: new Response("Admin access required.", { status: 403 }) };

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { clearSession, getRuntimeEnv, readSession } from "../../../lib/auth";
+import { clearSession, getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 export const prerender = false;
@@ -8,6 +8,10 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	const env = getRuntimeEnv();
 	const secureCookie = new URL(request.url).protocol === "https:";
 	const session = await readSession(request, env);
+	if (session) {
+		const sameOriginError = requireSameOrigin(request);
+		if (sameOriginError) return sameOriginError;
+	}
 	const cookie = await clearSession(env, secureCookie);
 	if (session?.email) {
 		await writeAudit(env, session.email, "sign_out", "session", 0, null, { email: session.email });

--- a/src/pages/api/games.ts
+++ b/src/pages/api/games.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../lib/auth";
 import { writeAudit } from "../../lib/audit";
 import { fetchExternalGameMetadata } from "../../lib/game-metadata";
 
@@ -114,6 +114,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const db = getDb(env);
 	if (!db) {
@@ -236,6 +238,8 @@ export const DELETE: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const db = getDb(env);
 	if (!db) {
@@ -340,6 +344,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 	if (session.role !== "admin") {
 		return new Response("Not authorized.", { status: 403 });
 	}

--- a/src/pages/api/games/eligibility.ts
+++ b/src/pages/api/games/eligibility.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type GameRow = {
@@ -29,6 +29,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	const id = normalizeGameId(body?.id);

--- a/src/pages/api/games/favorite.ts
+++ b/src/pages/api/games/favorite.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type D1Database = {
@@ -19,6 +19,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	const id = normalizeGameId(body?.id);

--- a/src/pages/api/games/rating.ts
+++ b/src/pages/api/games/rating.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type D1Database = {
@@ -94,6 +94,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	const id = normalizeGameId(body?.id);

--- a/src/pages/api/games/ttb.ts
+++ b/src/pages/api/games/ttb.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type D1Database = {
@@ -25,6 +25,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);

--- a/src/pages/api/me.ts
+++ b/src/pages/api/me.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { createSession, getRuntimeEnv, readSession } from "../../lib/auth";
+import { createSession, getRuntimeEnv, readSession, requireSameOrigin } from "../../lib/auth";
 import { writeAudit } from "../../lib/audit";
 
 export const prerender = false;
@@ -31,6 +31,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const body = await readJson(request);
 	if (!body || typeof body.alias !== "string") {

--- a/src/pages/api/polls.ts
+++ b/src/pages/api/polls.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../lib/auth";
 import { writeAudit } from "../../lib/audit";
 
 type D1Database = {
@@ -110,6 +110,8 @@ export const POST: APIRoute = async ({ locals, request }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const db = getDb(env);
 	if (!db) {
@@ -179,6 +181,8 @@ export const PATCH: APIRoute = async ({ locals, request }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const db = getDb(env);
 	if (!db) {

--- a/src/pages/api/polls/vote.ts
+++ b/src/pages/api/polls/vote.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type D1Database = {
@@ -20,6 +20,8 @@ export const POST: APIRoute = async ({ locals, request }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 
 	const db = getDb(env);
 	if (!db) {

--- a/src/pages/api/site-settings.ts
+++ b/src/pages/api/site-settings.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../lib/auth";
 import { writeAudit } from "../../lib/audit";
 
 type D1Database = {
@@ -41,6 +41,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const sameOriginError = requireSameOrigin(request);
+	if (sameOriginError) return sameOriginError;
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}

--- a/tests/e2e/authenticated-flows.spec.ts
+++ b/tests/e2e/authenticated-flows.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 import { createSessionCookie } from "./helpers/session-cookie";
 
+const SAME_ORIGIN_HEADERS = { Origin: "http://127.0.0.1:4321" };
+const CROSS_ORIGIN_HEADERS = { Origin: "https://evil.example" };
+
 function memberCookie() {
 	return createSessionCookie({
 		email: "member@example.com",
@@ -47,6 +50,7 @@ test("authenticated member cannot trigger admin game metadata refresh", async ({
 	const response = await request.post("/api/admin/games", {
 		headers: {
 			"Content-Type": "application/json",
+			...SAME_ORIGIN_HEADERS,
 			Cookie: memberCookie()
 		},
 		data: { action: "refresh-metadata-all" }
@@ -69,6 +73,7 @@ test("authenticated member cannot call admin member mutation", async ({ request 
 	const response = await request.post("/api/admin/members", {
 		headers: {
 			"Content-Type": "application/json",
+			...SAME_ORIGIN_HEADERS,
 			Cookie: memberCookie()
 		},
 		data: { email: "new-member@example.com", role: "member" }
@@ -81,6 +86,7 @@ test("favorite toggle validates payload when authenticated", async ({ request })
 	const response = await request.post("/api/games/favorite", {
 		headers: {
 			"Content-Type": "application/json",
+			...SAME_ORIGIN_HEADERS,
 			Cookie: memberCookie()
 		},
 		data: { id: "x", favorite: "yes" }
@@ -93,6 +99,7 @@ test("rating submit validates payload when authenticated", async ({ request }) =
 	const response = await request.post("/api/games/rating", {
 		headers: {
 			"Content-Type": "application/json",
+			...SAME_ORIGIN_HEADERS,
 			Cookie: memberCookie()
 		},
 		data: { id: "bad", rating: 7 }
@@ -105,6 +112,7 @@ test("admin member mutation enforces payload validation when authenticated", asy
 	const response = await request.post("/api/admin/members", {
 		headers: {
 			"Content-Type": "application/json",
+			...SAME_ORIGIN_HEADERS,
 			Cookie: adminCookie()
 		},
 		data: { email: "not-an-email", role: "member" }
@@ -117,10 +125,24 @@ test("admin game metadata refresh enforces payload validation when authenticated
 	const response = await request.post("/api/admin/games", {
 		headers: {
 			"Content-Type": "application/json",
+			...SAME_ORIGIN_HEADERS,
 			Cookie: adminCookie()
 		},
 		data: { action: "refresh-metadata" }
 	});
 	expect(response.status()).toBe(400);
 	await expect(response.text()).resolves.toContain("Game id is required.");
+});
+
+test("authenticated mutation rejects forged cross-origin requests", async ({ request }) => {
+	const response = await request.post("/api/games/favorite", {
+		headers: {
+			"Content-Type": "application/json",
+			...CROSS_ORIGIN_HEADERS,
+			Cookie: memberCookie()
+		},
+		data: { id: 1, favorite: true }
+	});
+	expect(response.status()).toBe(403);
+	await expect(response.text()).resolves.toContain("Same-origin request required.");
 });


### PR DESCRIPTION
## Summary

- Adds a shared same-origin guard for authenticated mutating requests.
- Applies the guard across member/admin game, poll, profile, site setting, and logout write endpoints.
- Updates authenticated API tests to send same-origin headers and adds a forged-origin regression test.

Closes #18.

## PR Shape

This PR is stacked on #31 (`codex/p0-astro-vite-security`) so the diff stays limited to CSRF hardening. Merge #31 first, then retarget this PR to `main` if GitHub does not do that automatically.

## Validation

- `HOME=/tmp XDG_CONFIG_HOME=/tmp XDG_DATA_HOME=/tmp WRANGLER_HOME=/tmp/wrangler npm run build`
- `npm --cache /private/tmp/npm-cache audit --omit=dev`
- `npm run test:e2e`