### PR TITLE
Harden CSRF defense with same-origin guard (issue #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-05-04
+1. Fixed issue #18 by adding a shared same-origin CSRF guard for authenticated state-changing API requests.
+2. Applied the guard to authenticated `POST`, `PATCH`, and `DELETE` handlers under `src/pages/api/**`, while leaving read-only requests and OAuth redirects unchanged.
+3. Added e2e regression coverage for forged-origin authenticated mutations.
+
 ## 2026-04-23
 1. Completed issue #15 by rebuilding the Home "Played" section as a Hall of Fame cover-art mosaic. Tiles show box art only at rest, with a scrim overlay on hover/focus that surfaces title, played month, aggregate rating, and tags; clicking a tile still opens the existing game detail modal.
 2. Added a capture-phase click handler gated on `(hover: none)` so touch devices get a first-tap-reveals / second-tap-opens interaction for the overlay.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
 	},
 	use: {
 		baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:4321",
-		headless: true
+		headless: true,
+		extraHTTPHeaders: {
+			Origin: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:4321"
+		}
 	},
 	webServer: {
 		command:

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -300,6 +300,24 @@ export function consumePendingSessionCookie(request: Request) {
 	return cookie;
 }
 
+export function requireSameOrigin(request: Request): Response | null {
+	const fetchSite = request.headers.get("Sec-Fetch-Site");
+	if (fetchSite === "same-origin" || fetchSite === "same-site") {
+		return null;
+	}
+	const origin = request.headers.get("Origin");
+	if (origin) {
+		try {
+			if (origin === new URL(request.url).origin) {
+				return null;
+			}
+		} catch {
+			// fall through
+		}
+	}
+	return new Response("Forbidden.", { status: 403 });
+}
+
 export function getRedirectUri(env: AuthEnv): string {
 	const redirectUri = getEnv(env, "GOOGLE_REDIRECT_URI");
 	if (!redirectUri) {

--- a/src/pages/api/admin/games.ts
+++ b/src/pages/api/admin/games.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 import { fetchExternalGameMetadata, type ExternalGameMetadata } from "../../../lib/game-metadata";
 
@@ -74,6 +74,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 
@@ -223,6 +225,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 export const PATCH: APIRoute = async ({ request, locals }) => {
 	const { session, db, error } = await requireAdmin(request, locals);
 	if (!session || !db) return error!;
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);
@@ -412,6 +416,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 export const DELETE: APIRoute = async ({ request, locals }) => {
 	const { session, db, error } = await requireAdmin(request, locals);
 	if (!session || !db) return error!;
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);

--- a/src/pages/api/admin/members.ts
+++ b/src/pages/api/admin/members.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type MemberRow = {
@@ -61,6 +61,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const email = normalizeEmail(body?.email);
@@ -114,6 +116,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const email = normalizeEmail(body?.email);
@@ -210,6 +214,8 @@ export const DELETE: APIRoute = async ({ request, locals }) => {
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const email = normalizeEmail(body?.email);

--- a/src/pages/api/admin/polls.ts
+++ b/src/pages/api/admin/polls.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type PollHistoryRow = {
@@ -69,6 +69,8 @@ export const GET: APIRoute = async ({ request, locals }) => {
 export const PATCH: APIRoute = async ({ request, locals }) => {
 	const { session, db, env, error } = await requireAdmin(request, locals);
 	if (!session || !db || !env) return error!;
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);
@@ -105,6 +107,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 export const DELETE: APIRoute = async ({ request, locals }) => {
 	const { session, db, env, error } = await requireAdmin(request, locals);
 	if (!session || !db || !env) return error!;
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);

--- a/src/pages/api/auth/logout.ts
+++ b/src/pages/api/auth/logout.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { clearSession, getRuntimeEnv, readSession } from "../../../lib/auth";
+import { clearSession, getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 export const prerender = false;
@@ -8,6 +8,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	const env = getRuntimeEnv(locals.runtime?.env);
 	const secureCookie = new URL(request.url).protocol === "https:";
 	const session = await readSession(request, env);
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 	const cookie = await clearSession(env, secureCookie);
 	if (session?.email) {
 		await writeAudit(env, session.email, "sign_out", "session", 0, null, { email: session.email });

--- a/src/pages/api/games.ts
+++ b/src/pages/api/games.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../lib/auth";
 import { writeAudit } from "../../lib/audit";
 import { fetchExternalGameMetadata } from "../../lib/game-metadata";
 
@@ -114,6 +114,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const db = getDb(env);
 	if (!db) {
@@ -236,6 +238,8 @@ export const DELETE: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const db = getDb(env);
 	if (!db) {
@@ -343,6 +347,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 	if (session.role !== "admin") {
 		return new Response("Not authorized.", { status: 403 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const db = getDb(env);
 	if (!db) {

--- a/src/pages/api/games/eligibility.ts
+++ b/src/pages/api/games/eligibility.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type GameRow = {
@@ -29,6 +29,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const id = normalizeGameId(body?.id);

--- a/src/pages/api/games/favorite.ts
+++ b/src/pages/api/games/favorite.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type D1Database = {
@@ -19,6 +19,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const id = normalizeGameId(body?.id);

--- a/src/pages/api/games/rating.ts
+++ b/src/pages/api/games/rating.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type D1Database = {
@@ -94,6 +94,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const id = normalizeGameId(body?.id);

--- a/src/pages/api/games/ttb.ts
+++ b/src/pages/api/games/ttb.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type D1Database = {
@@ -25,6 +25,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const id = normalizeId(body?.id);

--- a/src/pages/api/me.ts
+++ b/src/pages/api/me.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { createSession, getRuntimeEnv, readSession } from "../../lib/auth";
+import { createSession, getRuntimeEnv, readSession, requireSameOrigin } from "../../lib/auth";
 import { writeAudit } from "../../lib/audit";
 
 export const prerender = false;
@@ -31,6 +31,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	if (!body || typeof body.alias !== "string") {

--- a/src/pages/api/polls.ts
+++ b/src/pages/api/polls.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../lib/auth";
 import { writeAudit } from "../../lib/audit";
 
 type D1Database = {
@@ -110,6 +110,8 @@ export const POST: APIRoute = async ({ locals, request }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const db = getDb(env);
 	if (!db) {
@@ -179,6 +181,8 @@ export const PATCH: APIRoute = async ({ locals, request }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const db = getDb(env);
 	if (!db) {

--- a/src/pages/api/polls/vote.ts
+++ b/src/pages/api/polls/vote.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../../lib/auth";
 import { writeAudit } from "../../../lib/audit";
 
 type D1Database = {
@@ -20,6 +20,8 @@ export const POST: APIRoute = async ({ locals, request }) => {
 	if (!session) {
 		return new Response("Authentication required.", { status: 401 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const db = getDb(env);
 	if (!db) {

--- a/src/pages/api/site-settings.ts
+++ b/src/pages/api/site-settings.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getRuntimeEnv, readSession } from "../../lib/auth";
+import { getRuntimeEnv, readSession, requireSameOrigin } from "../../lib/auth";
 import { writeAudit } from "../../lib/audit";
 
 type D1Database = {
@@ -44,6 +44,8 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
 	if (session.role !== "admin") {
 		return new Response("Admin access required.", { status: 403 });
 	}
+	const csrf = requireSameOrigin(request);
+	if (csrf) return csrf;
 
 	const body = await readJson(request);
 	const value = typeof body?.next_meeting === "string" ? body.next_meeting.trim() : "";

--- a/tests/e2e/auth-and-guards.spec.ts
+++ b/tests/e2e/auth-and-guards.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { createSessionCookie } from "./helpers/session-cookie";
 
 test("unauthenticated /api/me returns 401", async ({ request }) => {
 	const response = await request.get("/api/me");
@@ -76,4 +77,22 @@ test("unauthenticated member admin mutation returns 401", async ({ request }) =>
 	});
 	expect(response.status()).toBe(401);
 	await expect(response.text()).resolves.toContain("Authentication required.");
+});
+
+test("authenticated mutation from a forged Origin returns 403", async ({ request }) => {
+	const cookie = createSessionCookie({
+		email: "member@example.com",
+		role: "member",
+		name: "Member User"
+	});
+	const response = await request.post("/api/games/favorite", {
+		headers: {
+			"Content-Type": "application/json",
+			Cookie: cookie,
+			Origin: "https://evil.example"
+		},
+		data: { id: 1, favorite: true }
+	});
+	expect(response.status()).toBe(403);
+	await expect(response.text()).resolves.toContain("Forbidden.");
 });


### PR DESCRIPTION
## Summary
- Adds `requireSameOrigin(request)` in `src/lib/auth.ts`. Returns 403 unless `Sec-Fetch-Site` is `same-origin`/`same-site` **or** the `Origin` header matches the request URL's origin.
- Applies the guard to every authenticated `POST/PATCH/DELETE` handler under `src/pages/api/**` (right after the auth/admin check, per the issue spec). GET/HEAD and OAuth redirects are untouched.
- Adds a forged-Origin regression test in `tests/e2e/auth-and-guards.spec.ts` and sets `extraHTTPHeaders.Origin` in `playwright.config.ts` so existing authenticated POST tests stay same-origin under Playwright's request API.

Reimplements the fix from issue #18 (P0) that was lost in a recent rollback.

## Endpoints hardened
- `POST /api/auth/logout`
- `POST/PATCH/DELETE /api/games`
- `PATCH /api/me`
- `PATCH /api/site-settings`
- `POST/PATCH /api/polls`, `POST /api/polls/vote`
- `POST /api/games/favorite`, `/rating`, `/eligibility`, `/ttb`
- `PATCH/DELETE /api/admin/polls`
- `POST/PATCH/DELETE /api/admin/members`
- `POST/PATCH/DELETE /api/admin/games`

## Validation
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — **24/24 passing**, including the new forged-Origin regression test
- [ ] Cloudflare Pages preview deploys successfully for this branch
- [ ] Smoke: `GET /` and `GET /api/games` return successful responses on the preview
- [ ] Sign-in flow still works on the preview (OAuth redirect is GET, not gated)
- [ ] Authenticated mutations from the SPA succeed (favorite a game, rate a game)

🤖 Generated with [Claude Code](https://claude.com/claude-code)